### PR TITLE
fish: Move mate symlink provisioning out of startup

### DIFF
--- a/dot_config/fish/conf.d/052-mate.fish
+++ b/dot_config/fish/conf.d/052-mate.fish
@@ -1,3 +1,0 @@
-if test -f /Applications/TextMate.app/Contents/MacOS/mate && not test -e ~/bin/mate
-  ln -s /Applications/TextMate.app/Contents/MacOS/mate ~/bin/mate
-end

--- a/run_once_after_install-mate.sh
+++ b/run_once_after_install-mate.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEXTMATE_APP="/Applications/TextMate.app/Contents/MacOS/mate"
+MATE_LINK="${HOME}/bin/mate"
+
+if [[ -f "${TEXTMATE_APP}" && ! -e "${MATE_LINK}" ]]; then
+  mkdir -p "${HOME}/bin"
+  ln -s "${TEXTMATE_APP}" "${MATE_LINK}"
+fi


### PR DESCRIPTION
Move TextMate symlink creation to an after-install run script and remove side effects from fish startup config.

Fixes #3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple dotfiles automation change that only affects local symlink provisioning and reduces startup-time side effects.
> 
> **Overview**
> Removes the TextMate `mate` symlink creation from Fish startup (`conf.d/052-mate.fish`) to avoid side effects during shell initialization.
> 
> Adds a `run_once_after_install-mate.sh` script that, after install, creates `~/bin/mate` pointing to `/Applications/TextMate.app/Contents/MacOS/mate` when the app exists and the link is missing (ensuring `~/bin` exists first).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 824ae73dfaea07a2113115bbb3fb0997fdebb6c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->