### PR TITLE
Add safeguards to destructive shell helpers

### DIFF
--- a/dot_config/fish/functions/docker_nuke.fish
+++ b/dot_config/fish/functions/docker_nuke.fish
@@ -9,17 +9,65 @@ function docker_nuke --description "Stop and remove all Docker resources"
     return 0
   end
 
-  if not set -q _flag_f
-    set -l prompt "This will stop all containers and delete Docker containers, images, and networks"
+  if not command -sq docker
+    echo "docker command not found."
+    return 1
+  end
 
-    if set -q _flag_v
-      set prompt "$prompt, plus volumes"
+  if not docker info >/dev/null 2>&1
+    echo "Docker daemon is not available."
+    return 1
+  end
+
+  set -l docker_context (docker context show)
+  set -l running (docker ps -q)
+  set -l containers (docker ps -aq)
+  set -l images (docker images -aq)
+  set -l networks (docker network ls --format '{{.Name}}' | string match -v -r '^(bridge|host|none)$')
+  set -l volumes (docker volume ls -q)
+
+  set -l running_count (count $running)
+  set -l container_count (count $containers)
+  set -l image_count (count $images)
+  set -l network_count (count $networks)
+  set -l volume_count (count $volumes)
+
+  set -l removable_volumes_count 0
+  if set -q _flag_v
+    set removable_volumes_count $volume_count
+  end
+
+  set -l total_count (math $running_count + $container_count + $image_count + $network_count + $removable_volumes_count)
+  set -l stopped_count (math $container_count - $running_count)
+
+  if test $total_count -eq 0
+    echo "No Docker resources to remove."
+    return 0
+  end
+
+  if not set -q _flag_f
+    if not status is-interactive
+      echo "Refusing to ask for confirmation in non-interactive mode. Use --force."
+      return 1
     end
 
-    set prompt "$prompt. Continue? [y/N] "
+    echo "Context: $docker_context"
+    echo "About to remove:"
+    echo "  - $running_count running containers"
+    echo "  - $stopped_count stopped containers"
+    echo "  - $image_count images"
+    echo "  - $network_count networks"
+    if set -q _flag_v
+      echo "  - $volume_count volumes"
+    end
+
+    set -l prompt "This will stop all containers and delete Docker containers, images, and networks"
+    set prompt "$prompt, plus volumes if any."
+
+    set prompt "$prompt Confirm by typing \"DESTROY DOCKER\" (exactly). "
     read -l -P $prompt confirm
 
-    if test "$confirm" != "y" -a "$confirm" != "Y"
+    if test "$confirm" != "DESTROY DOCKER"
       echo "Aborted."
       return 1
     end

--- a/dot_config/fish/functions/zellij_reset.fish
+++ b/dot_config/fish/functions/zellij_reset.fish
@@ -1,4 +1,48 @@
 function zellij_reset
+  argparse --name=zellij_reset f/force h/help -- $argv
+
+  if set -q _flag_h
+    echo "Usage: zellij_reset [--force]"
+    echo "Kill and delete all zellij sessions."
+    echo "  -f, --force    Skip confirmation."
+    return 0
+  end
+
+  if not command -sq zellij
+    echo "zellij command not found."
+    return 1
+  end
+
+  set -l sessions (zellij list-sessions 2>/dev/null)
+  set -l session_count (count $sessions)
+
+  if test $session_count -eq 0
+    echo "No zellij sessions found."
+    return 0
+  end
+
+  if not set -q _flag_f
+    if not status is-interactive
+      echo "Refusing to ask for confirmation in non-interactive mode. Use --force."
+      return 1
+    end
+
+    echo "This will kill and delete all ($session_count) zellij sessions."
+    for session in $sessions
+      set -l cleaned_session (string trim $session)
+      if test -n "$cleaned_session"
+        echo "  - $cleaned_session"
+      end
+    end
+    set -l confirm
+    read -l -P "Type \"RESET ZELLIJ\" to confirm: " confirm
+
+    if test "$confirm" != "RESET ZELLIJ"
+      echo "Aborted."
+      return 1
+    end
+  end
+
   zellij kill-all-sessions --yes
   zellij delete-all-sessions --yes
 end


### PR DESCRIPTION
Fixes #5.

This adds stronger confirmations and preflight checks to docker_nuke and zellij_reset before destructive actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to local shell helper UX and guardrails; risk is mainly altered behavior in automation due to the new non-interactive refusal/confirmation requirements.
> 
> **Overview**
> Tightens safeguards around destructive Fish helpers.
> 
> `docker_nuke` now performs preflight checks (Docker CLI present, daemon reachable), computes and prints a per-resource removal summary (including current context), exits early when there’s nothing to delete, refuses to prompt in non-interactive mode unless `--force` is used, and requires typing `DESTROY DOCKER` to proceed.
> 
> `zellij_reset` now adds `--help/--force`, validates the `zellij` binary exists, lists sessions with a count and exits early when none exist, blocks non-interactive confirmation unless `--force` is used, and requires typing `RESET ZELLIJ` before killing/deleting sessions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5f571f99c3d32f371a7a16b449992ca18b77a9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->